### PR TITLE
4 fallende objekte

### DIFF
--- a/wildbeat/scenes/falling_objects/falling_object.tscn
+++ b/wildbeat/scenes/falling_objects/falling_object.tscn
@@ -1,0 +1,28 @@
+[gd_scene load_steps=3 format=3 uid="uid://d2h5ih1js8lnd"]
+
+[ext_resource type="Script" uid="uid://t2llmtc6yw1k" path="res://scripts/falling_objects/falling_object.gd" id="1_0noha"]
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_00vvc"]
+size = Vector2(48, 48)
+
+[node name="FallingObject" type="Area2D" groups=["FallingObject"]]
+script = ExtResource("1_0noha")
+
+[node name="ColorRect" type="ColorRect" parent="."]
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -24.0
+offset_top = -24.0
+offset_right = 24.0
+offset_bottom = 24.0
+grow_horizontal = 2
+grow_vertical = 2
+color = Color(0.808409, 0, 0.332176, 1)
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+light_mask = 2
+visibility_layer = 0
+shape = SubResource("RectangleShape2D_00vvc")

--- a/wildbeat/scenes/falling_objects/object_spawner.tscn
+++ b/wildbeat/scenes/falling_objects/object_spawner.tscn
@@ -1,0 +1,20 @@
+[gd_scene load_steps=2 format=3 uid="uid://bt6shla866s4b"]
+
+[ext_resource type="Script" uid="uid://dsq638hehfnxd" path="res://scripts/falling_objects/object_spawner.gd" id="1_jomer"]
+
+[node name="ObjectSpawner" type="Node2D"]
+script = ExtResource("1_jomer")
+
+[node name="ColorRect" type="ColorRect" parent="."]
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -20.0
+offset_top = -20.0
+offset_right = 20.0
+offset_bottom = 20.0
+grow_horizontal = 2
+grow_vertical = 2
+color = Color(0.847202, 0.639088, 0, 1)

--- a/wildbeat/scenes/level/game_level.tscn
+++ b/wildbeat/scenes/level/game_level.tscn
@@ -1,9 +1,11 @@
-[gd_scene load_steps=8 format=4 uid="uid://60y25u23qmk0"]
+[gd_scene load_steps=11 format=4 uid="uid://60y25u23qmk0"]
 
 [ext_resource type="Script" uid="uid://b11mhg21yfbaq" path="res://scripts/level/level.gd" id="1_7comb"]
 [ext_resource type="Texture2D" uid="uid://jbxi4ur45xs5" path="res://scenes/level/tetrominoes.png" id="2_4k7sf"]
 [ext_resource type="Texture2D" uid="uid://dbhi62j7h40jd" path="res://icon.svg" id="3_8vk10"]
 [ext_resource type="Script" uid="uid://c6sx6613w175b" path="res://scripts/level/player/player.gd" id="3_45x5i"]
+[ext_resource type="PackedScene" uid="uid://bt6shla866s4b" path="res://scenes/falling_objects/object_spawner.tscn" id="5_k86hv"]
+[ext_resource type="Script" uid="uid://4j5kwr4it1b7" path="res://scripts/level/world_border.gd" id="6_is3dy"]
 
 [sub_resource type="TileSetAtlasSource" id="TileSetAtlasSource_8vk10"]
 texture = ExtResource("2_4k7sf")
@@ -45,6 +47,9 @@ sources/0 = SubResource("TileSetAtlasSource_8vk10")
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_45x5i"]
 
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_k86hv"]
+size = Vector2(752, 16)
+
 [node name="Level" type="Node2D"]
 script = ExtResource("1_7comb")
 
@@ -61,8 +66,35 @@ script = ExtResource("3_45x5i")
 [node name="CharacterBody2D" type="CharacterBody2D" parent="Player"]
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Player/CharacterBody2D"]
+visibility_layer = 2
 shape = SubResource("RectangleShape2D_45x5i")
 
 [node name="Sprite2D" type="Sprite2D" parent="Player"]
 scale = Vector2(0.5, 0.5)
 texture = ExtResource("3_8vk10")
+
+[node name="ObjectSpawner" parent="." instance=ExtResource("5_k86hv")]
+position = Vector2(168, 118)
+
+[node name="WorldBorder" type="Area2D" parent="."]
+position = Vector2(376, 632)
+script = ExtResource("6_is3dy")
+
+[node name="ColorRect" type="ColorRect" parent="WorldBorder"]
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -376.0
+offset_top = -8.0
+offset_right = 376.0
+offset_bottom = 8.0
+grow_horizontal = 2
+grow_vertical = 2
+color = Color(3.60981e-07, 0.501618, 0.127517, 1)
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="WorldBorder"]
+light_mask = 4
+visibility_layer = 0
+shape = SubResource("RectangleShape2D_k86hv")

--- a/wildbeat/scripts/falling_objects/falling_object.gd
+++ b/wildbeat/scripts/falling_objects/falling_object.gd
@@ -1,0 +1,7 @@
+extends Area2D
+
+const FALL_SPEED := 100.0  # Pixel pro Sekunde
+
+func _physics_process(delta: float) -> void:
+	self.position.y = self.position.y + FALL_SPEED * delta
+	

--- a/wildbeat/scripts/falling_objects/falling_object.gd.uid
+++ b/wildbeat/scripts/falling_objects/falling_object.gd.uid
@@ -1,0 +1,1 @@
+uid://t2llmtc6yw1k

--- a/wildbeat/scripts/falling_objects/object_spawner.gd
+++ b/wildbeat/scripts/falling_objects/object_spawner.gd
@@ -1,0 +1,28 @@
+extends Node2D
+
+@export var object_scene: PackedScene = preload("res://scenes/falling_objects/falling_object.tscn")
+@export var spawn_position: Vector2 = Vector2(0, 0)
+
+@onready var spawn_timer := Timer.new()
+
+func _ready():
+	spawn_timer.one_shot = true # Timer muss ablaufen bevor er neu starten kann
+	spawn_timer.timeout.connect(_on_spawn_timer_timeout)
+	add_child(spawn_timer)
+	_start_random_spawn()
+
+# Setze Timer auf einen zufälligen Spawnintervall zwischen 2 und 5 Sekunden
+func _start_random_spawn():
+	var wait_time = randf_range(2.0, 5.0)
+	spawn_timer.start(wait_time)
+
+# Spawne neues Objekt wenn Timer abgelaufen ist und starte Timer neu
+func _on_spawn_timer_timeout():
+	spawn_object()
+	_start_random_spawn()
+
+# Spawn neues Objekt an der Position des Spawners, wenn Timer abgelaufen ist
+func spawn_object():
+	var spawned_object = object_scene.instantiate()
+	spawned_object.global_position = spawn_position
+	add_child(spawned_object)

--- a/wildbeat/scripts/falling_objects/object_spawner.gd.uid
+++ b/wildbeat/scripts/falling_objects/object_spawner.gd.uid
@@ -1,0 +1,1 @@
+uid://dsq638hehfnxd

--- a/wildbeat/scripts/level/world_border.gd
+++ b/wildbeat/scripts/level/world_border.gd
@@ -1,0 +1,8 @@
+extends Area2D
+
+func _ready():
+	area_entered.connect(_on_area_entered)
+
+func _on_area_entered(area: Area2D) -> void:
+	if area.is_in_group("FallingObject"):
+		area.queue_free()

--- a/wildbeat/scripts/level/world_border.gd.uid
+++ b/wildbeat/scripts/level/world_border.gd.uid
@@ -1,0 +1,1 @@
+uid://4j5kwr4it1b7


### PR DESCRIPTION
**Spawner hinzugefügt, der fallende Objekte zufällig generiert.**
Bisher nur 1 Spawner im Level eingesetzt, kann aber einfach neu hinzugefügt werden, da Spawner eine einzelne Szene ist.
Optisch sind das im Moment nur farbliche Blöcke.
Fallende Objekte haben eine Collision Shape, bewegen sich aber trotzdem durch den Spieler durch.
World Border unterhalb des Spielfeld hinzugefügt. Diese zerstört fallende Objekte, die mit ihr kollidieren.