### PR TITLE
Visuelle Herzen hinzugefügt, die die Spielerleben anzeigen

### DIFF
--- a/wildbeat/project.godot
+++ b/wildbeat/project.godot
@@ -23,6 +23,8 @@ GameManager="*res://scripts/globals/game_manager.gd"
 [display]
 
 window/size/viewport_width=750
+window/stretch/mode="viewport"
+window/stretch/aspect="expand"
 
 [global_group]
 
@@ -48,3 +50,7 @@ pause_game={
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194305,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
 ]
 }
+
+[rendering]
+
+textures/canvas_textures/default_texture_filter=0

--- a/wildbeat/scenes/level/game_level.tscn
+++ b/wildbeat/scenes/level/game_level.tscn
@@ -1,10 +1,11 @@
-[gd_scene load_steps=11 format=4 uid="uid://do5p8wqmnca6j"]
+[gd_scene load_steps=10 format=4 uid="uid://do5p8wqmnca6j"]
 
 [ext_resource type="Script" uid="uid://b11mhg21yfbaq" path="res://scripts/level/level.gd" id="1_7comb"]
 [ext_resource type="Texture2D" uid="uid://jbxi4ur45xs5" path="res://scenes/level/tetrominoes.png" id="2_4k7sf"]
 [ext_resource type="PackedScene" uid="uid://biefbfjfggjbt" path="res://scenes/level/player.tscn" id="3_k86hv"]
 [ext_resource type="PackedScene" uid="uid://bt6shla866s4b" path="res://scenes/falling_objects/object_spawner.tscn" id="5_k86hv"]
-[ext_resource type="Script" path="res://scripts/level/world_border.gd" id="6_is3dy"]
+[ext_resource type="Script" uid="uid://4j5kwr4it1b7" path="res://scripts/level/world_border.gd" id="6_is3dy"]
+[ext_resource type="PackedScene" uid="uid://cr4svtv42h0jx" path="res://scenes/user_interface/hearts_container.tscn" id="6_tdwdi"]
 
 [sub_resource type="TileSetAtlasSource" id="TileSetAtlasSource_8vk10"]
 texture = ExtResource("2_4k7sf")
@@ -84,3 +85,7 @@ color = Color(3.60981e-07, 0.501618, 0.127517, 1)
 light_mask = 4
 visibility_layer = 0
 shape = SubResource("RectangleShape2D_k86hv")
+
+[node name="UserInterface" type="CanvasLayer" parent="."]
+
+[node name="HeartsContainer" parent="UserInterface" instance=ExtResource("6_tdwdi")]

--- a/wildbeat/scenes/level/player.tscn
+++ b/wildbeat/scenes/level/player.tscn
@@ -3,7 +3,6 @@
 [ext_resource type="Script" uid="uid://c6sx6613w175b" path="res://scripts/level/player/player.gd" id="1_7h6ip"]
 [ext_resource type="Texture2D" uid="uid://dbhi62j7h40jd" path="res://icon.svg" id="2_7h6ip"]
 
-
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_dovo2"]
 
 [node name="CharacterBody2DTEST" type="CharacterBody2D" groups=["player"]]

--- a/wildbeat/scenes/user_interface/heart_gui.tscn
+++ b/wildbeat/scenes/user_interface/heart_gui.tscn
@@ -1,0 +1,39 @@
+[gd_scene load_steps=2 format=3 uid="uid://b0fioa7mcqgci"]
+
+[ext_resource type="Script" uid="uid://cekhhaysw4785" path="res://scripts/user_interface/heart_gui.gd" id="1_vy5e0"]
+
+[node name="heartGUI" type="Panel"]
+self_modulate = Color(1, 1, 1, 0)
+custom_minimum_size = Vector2(32, 32)
+offset_right = 32.0
+offset_bottom = 32.0
+script = ExtResource("1_vy5e0")
+
+[node name="Filled" type="ColorRect" parent="."]
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -8.0
+offset_top = -8.0
+offset_right = 8.0
+offset_bottom = 8.0
+grow_horizontal = 2
+grow_vertical = 2
+color = Color(0.882165, 0, 0.108054, 1)
+
+[node name="Empty" type="ColorRect" parent="."]
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -8.0
+offset_top = -8.0
+offset_right = 8.0
+offset_bottom = 8.0
+grow_horizontal = 2
+grow_vertical = 2

--- a/wildbeat/scenes/user_interface/hearts_container.tscn
+++ b/wildbeat/scenes/user_interface/hearts_container.tscn
@@ -1,0 +1,7 @@
+[gd_scene load_steps=2 format=3 uid="uid://cr4svtv42h0jx"]
+
+[ext_resource type="Script" uid="uid://bnyrb158dpu2e" path="res://scripts/user_interface/hearts_container.gd" id="1_axlr1"]
+
+[node name="HeartsContainer" type="HBoxContainer"]
+layout_direction = 3
+script = ExtResource("1_axlr1")

--- a/wildbeat/scripts/level/level.gd
+++ b/wildbeat/scripts/level/level.gd
@@ -3,6 +3,7 @@ extends Node2D
 @onready var board : TileMapLayer = $Board
 @onready var player: Node2D = $Player
 @onready var pause_menu = preload("res://scenes/menu/pause_menu.tscn").instantiate()
+@onready var heartsContainer: HBoxContainer = $UserInterface/HeartsContainer
 
 const TOTAL_TILES := 31
 const BORDER_TILES := 2
@@ -38,3 +39,8 @@ func _ready():
 
 	# Spieler global setzen
 	player.global_position = player_pixel_pos
+	
+	# User Interface
+	heartsContainer.set_max_hearts(player.max_health)
+	heartsContainer.update_hearts(player.current_health)
+	player.health_changed.connect(heartsContainer.update_hearts)

--- a/wildbeat/scripts/level/player/player.gd
+++ b/wildbeat/scripts/level/player/player.gd
@@ -3,7 +3,7 @@ extends Node2D
 @onready var board : TileMapLayer = get_parent().get_node("Board")
 
 @export var max_health := 3
-var current_healh := 0
+var current_health := 0
 
 const COLUMNS := 5
 const TILES_PER_COLUMN : int = 6
@@ -11,9 +11,11 @@ const BORDER_TILES : int = 2
 
 var current_column : int = 2
 
+signal health_changed
+
 func _ready():
 	move_to_column(current_column)
-	current_healh = max_health
+	current_health = max_health
 
 func _process(delta):
 	if Input.is_action_just_pressed("move_left") and current_column > 0:
@@ -42,7 +44,8 @@ func player_dies():
 
 func take_damage(damage : int = 1):
 	print("taking damage: " + str(damage))
-	current_healh -= damage
-	if current_healh <= 0:
+	current_health -= damage
+	health_changed.emit(current_health)
+	if current_health <= 0:
 		player_dies()
 	

--- a/wildbeat/scripts/user_interface/heart_gui.gd
+++ b/wildbeat/scripts/user_interface/heart_gui.gd
@@ -1,0 +1,12 @@
+extends Panel
+
+@onready var filled_rect: ColorRect = $Filled
+@onready var empty_rect: ColorRect = $Empty 
+
+func update(filled: bool) -> void:
+	if filled:
+		filled_rect.visible = true
+		empty_rect.visible = false
+	else:
+		filled_rect.visible = false
+		empty_rect.visible = true

--- a/wildbeat/scripts/user_interface/heart_gui.gd.uid
+++ b/wildbeat/scripts/user_interface/heart_gui.gd.uid
@@ -1,0 +1,1 @@
+uid://cekhhaysw4785

--- a/wildbeat/scripts/user_interface/hearts_container.gd
+++ b/wildbeat/scripts/user_interface/hearts_container.gd
@@ -1,0 +1,17 @@
+extends HBoxContainer
+
+@onready var HeartGui = preload("res://scenes/user_interface/heart_gui.tscn")
+
+func set_max_hearts(max: int) -> void:
+	for i in range(max):
+		var heart = HeartGui.instantiate()
+		add_child(heart)
+
+func update_hearts(current_health: int) -> void:
+	var hearts = get_children()
+	
+	for i in range(current_health):
+		hearts[i].update(true)
+	
+	for i in range(current_health, hearts.size()):
+		hearts[i].update(false)

--- a/wildbeat/scripts/user_interface/hearts_container.gd.uid
+++ b/wildbeat/scripts/user_interface/hearts_container.gd.uid
@@ -1,0 +1,1 @@
+uid://bnyrb158dpu2e


### PR DESCRIPTION
- Anzeige in der rechten oberen Ecke
- vorerst nur mit farbigen Rechtecken, kann einfach ersetzt werden mit Sprites
- orientiert sich an player.current_health & player.max_health