### PR TITLE
Removing Warnings from project

### DIFF
--- a/wildbeat/scenes/level/game_level.tscn
+++ b/wildbeat/scenes/level/game_level.tscn
@@ -1,10 +1,10 @@
-[gd_scene load_steps=10 format=4 uid="uid://do5p8wqmnca6j"]
+[gd_scene load_steps=10 format=4 uid="uid://60y25u23qmk0"]
 
 [ext_resource type="Script" uid="uid://b11mhg21yfbaq" path="res://scripts/level/level.gd" id="1_7comb"]
 [ext_resource type="Texture2D" uid="uid://jbxi4ur45xs5" path="res://scenes/level/tetrominoes.png" id="2_4k7sf"]
-[ext_resource type="PackedScene" uid="uid://biefbfjfggjbt" path="res://scenes/level/player.tscn" id="3_k86hv"]
+[ext_resource type="PackedScene" uid="uid://c7j53cdm6feex" path="res://scenes/level/player.tscn" id="3_k86hv"]
 [ext_resource type="PackedScene" uid="uid://bt6shla866s4b" path="res://scenes/falling_objects/object_spawner.tscn" id="5_k86hv"]
-[ext_resource type="Script" uid="uid://4j5kwr4it1b7" path="res://scripts/level/world_border.gd" id="6_is3dy"]
+[ext_resource type="Script" path="res://scripts/level/world_border.gd" id="6_is3dy"]
 [ext_resource type="PackedScene" uid="uid://cr4svtv42h0jx" path="res://scenes/user_interface/hearts_container.tscn" id="6_tdwdi"]
 
 [sub_resource type="TileSetAtlasSource" id="TileSetAtlasSource_8vk10"]

--- a/wildbeat/scenes/level/level_1.tscn
+++ b/wildbeat/scenes/level/level_1.tscn
@@ -1,3 +1,3 @@
-[gd_scene format=3 uid="uid://byp8402vu0db6"]
+[gd_scene format=3 uid="uid://dpma5473pgit8"]
 
 [node name="Level1" type="Node2D"]

--- a/wildbeat/scenes/level/player.tscn
+++ b/wildbeat/scenes/level/player.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=4 format=3 uid="uid://biefbfjfggjbt"]
+[gd_scene load_steps=4 format=3 uid="uid://c7j53cdm6feex"]
 
 [ext_resource type="Script" uid="uid://c6sx6613w175b" path="res://scripts/level/player/player.gd" id="1_7h6ip"]
 [ext_resource type="Texture2D" uid="uid://dbhi62j7h40jd" path="res://icon.svg" id="2_7h6ip"]

--- a/wildbeat/scripts/level/level.gd
+++ b/wildbeat/scripts/level/level.gd
@@ -5,17 +5,15 @@ extends Node2D
 @onready var pause_menu = preload("res://scenes/menu/pause_menu.tscn").instantiate()
 @onready var heartsContainer: HBoxContainer = $UserInterface/HeartsContainer
 
-const TOTAL_TILES := 31
-const BORDER_TILES := 2
-const PLAYABLE_TILES := TOTAL_TILES - BORDER_TILES  # 30
-const COLUMNS := 5
-const TILES_PER_COLUMN := PLAYABLE_TILES / COLUMNS  # 6
-const TILE_SIZE := 16  # in Pixeln
+const TOTAL_TILES : float = 31
+const BORDER_TILES : float = 2
+const PLAYABLE_TILES : float = TOTAL_TILES - BORDER_TILES  # 30
+const COLUMNS : float = 5
+const TILES_PER_COLUMN : float = PLAYABLE_TILES / COLUMNS  # 6
+const TILE_SIZE : float = 16  # in Pixeln
 	
 func _ready():
 	get_node("/root/GameManager").add_child(pause_menu)
-	#val bla = get_tree().path
-	#bla.add_child()
 	var screen_size = get_viewport().get_visible_rect().size
 	var board_pixel_width = TOTAL_TILES * TILE_SIZE
 

--- a/wildbeat/scripts/level/player/player.gd
+++ b/wildbeat/scripts/level/player/player.gd
@@ -5,9 +5,9 @@ extends Node2D
 @export var max_health := 3
 var current_health := 0
 
-const COLUMNS := 5
-const TILES_PER_COLUMN : int = 6
-const BORDER_TILES : int = 2
+const COLUMNS : float = 5
+const TILES_PER_COLUMN : float = 6
+const BORDER_TILES : float = 2
 
 var current_column : int = 2
 
@@ -17,7 +17,7 @@ func _ready():
 	move_to_column(current_column)
 	current_health = max_health
 
-func _process(delta):
+func _process(_delta):
 	if Input.is_action_just_pressed("move_left") and current_column > 0:
 		current_column -= 1
 		move_to_column(current_column)
@@ -33,7 +33,7 @@ func move_to_column(column_index: int):
 	var start_x = BORDER_TILES / 2
 	var tile_x = start_x + column_index * TILES_PER_COLUMN + (TILES_PER_COLUMN - 1) / 2.0
 
-	var tile_pos = Vector2(tile_x, target_tile_y)
+	var tile_pos = Vector2(int(tile_x), target_tile_y)
 	var pixel_pos = board.map_to_local(tile_pos) + board.position
 
 	global_position = pixel_pos

--- a/wildbeat/scripts/user_interface/hearts_container.gd
+++ b/wildbeat/scripts/user_interface/hearts_container.gd
@@ -2,8 +2,8 @@ extends HBoxContainer
 
 @onready var HeartGui = preload("res://scenes/user_interface/heart_gui.tscn")
 
-func set_max_hearts(max: int) -> void:
-	for i in range(max):
+func set_max_hearts(max_hearts: int) -> void:
+	for i in range(max_hearts):
 		var heart = HeartGui.instantiate()
 		add_child(heart)
 


### PR DESCRIPTION
PR ursprünglich dafür gedacht worden, die Kamera-Position zu fixen. Da es keine Kamera gibt und das Spielbrett relativ zur Spielfenstergröße gesetzt wird, gibt es auch keinen Bug.

Stattdessen habe ich den PR noch genutzt, um Warnings zu eliminieren:

- Godot hat keine Methoden für ganzzahlige Integer-Divisionen. Dadurch habe ich den Typen der Konstanten auf float geändert und caste diese bei der Berechnung zu integern.
- max ist eine built-in Methode von Godot. Ich habe für die Spielerherzen die Variable in max_hearts umbenannt.